### PR TITLE
fix: livekit token

### DIFF
--- a/src/main/java/com/uade/bookybe/core/usecase/impl/DefaultLivekitTokenService.java
+++ b/src/main/java/com/uade/bookybe/core/usecase/impl/DefaultLivekitTokenService.java
@@ -50,12 +50,18 @@ public class DefaultLivekitTokenService implements LivekitTokenService {
 
             // Set participant identity
             token.setIdentity(participantId);
-            token.setName(participantId);
+
+            // Add room join grant and video grants for publish/subscribe
+            token.addGrants(
+                new io.livekit.server.RoomJoin(true),
+                new io.livekit.server.RoomName(roomName),
+                new io.livekit.server.CanPublish(canPublish),
+                new io.livekit.server.CanSubscribe(canSubscribe)
+            );
 
             // Set token expiration using configured TTL
             token.setExpiration(Date.from(Instant.now().plusSeconds(livekitProps.getTokenTtlSeconds())));
-            // Create a basic token for now - the API seems to be different
-            // This is a simplified version that should work
+
             return token.toJwt();
 
         } catch (Exception e) {


### PR DESCRIPTION
This pull request updates the token creation logic in the `DefaultLivekitTokenService` to enhance participant permissions when joining a room. The main improvement is the addition of explicit grants for room joining, publishing, and subscribing, which provides finer control over participant capabilities.

**LiveKit token grant enhancements:**

* Added explicit grants for room joining (`RoomJoin`), room name (`RoomName`), publishing (`CanPublish`), and subscribing (`CanSubscribe`) when creating a participant token in `createJoinToken`. This ensures that tokens now include the necessary permissions for video room operations.